### PR TITLE
reorder arrival departure message for readability & alignment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ async fn main() -> Result<(), Box<dyn StdError>> {
 
                         // println!("{}  ❌ {} ₳", address, ada);
 
-                        let departuresmsg: String = format!("{}  ❌ {} ₳", address, ada);
+                        let departuresmsg: String = format!("❌ {} ₳ from {}  ", ada, address);
 
                         Matrix::message(&departuresmsg).await?;
 
@@ -223,7 +223,7 @@ async fn main() -> Result<(), Box<dyn StdError>> {
 
                         // println!("{}  ✅ {} ₳", address, ada);
 
-                        let arrivalsmsg: String = format!("{}  ✅ {} ₳", address, ada);
+                        let arrivalsmsg: String = format!("✅ {} ₳ from {}  ", ada, address);
 
                         Matrix::message(&arrivalsmsg).await?;
 


### PR DESCRIPTION
Now that multiple messages are coming in, I thought it would look cleaner to start with the emoji up front, then ada amount, and then from stake addr, so that quickly vertically scanning emoji's are aligned and amounts can be quickly scanned.